### PR TITLE
[Issue 4] RelatedList isLoaded also needs to super.isLoaded().

### DIFF
--- a/src/main/java/com/redhat/darcy/salesforce/RelatedList.java
+++ b/src/main/java/com/redhat/darcy/salesforce/RelatedList.java
@@ -86,7 +86,7 @@ public abstract class RelatedList<T extends RelatedList<T>> extends AbstractView
 
     @Override
     public boolean isLoaded() {
-        return !loadingSpinner.isDisplayed();
+    	return super.isLoaded() && !loadingSpinner.isDisplayed();
     }
 
     public Browser getContext() {


### PR DESCRIPTION
RelatedList isLoaded() should also super.isLoaded() in addition to waiting for the spinner to disappear.
